### PR TITLE
Issues #132 - Add eluvio-live object to tenant

### DIFF
--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -42,23 +42,6 @@ class ElvAccount {
     this.client.signer = this.signer;
     this.client.ToggleLogging(this.debug);
 
-    //Automatic fix: convert tenant admin group id to tenant contract id 
-    const idType = await this.client.AccessType({ id });
-    if (idType === this.client.authClient.ACCESS_TYPES.GROUP) {
-      let groupAddress = this.client.utils.HashToAddress(id);
-
-      let tenantContractIdHex = await this.client.CallContractMethod({
-        contractAddress: groupAddress,
-        methodName: "getMeta",
-        methodArgs: ["_ELV_TENANT_ID"], 
-      });
-
-      if (tenantContractIdHex == "0x") {
-        let args = group.split("_");
-        throw (`${args[0]} ${args[1]} group is not associated with any tenant`);
-      }
-      id = ethers.utils.toUtf8String(tenantContractIdHex);
-    }
     await this.SetAccountTenantContractId({ id });
   }
 
@@ -200,6 +183,24 @@ class ElvAccount {
   async SetAccountTenantContractId({ id }) {
     if (!this.client) {
       throw Error("ElvAccount not intialized");
+    }
+
+    //Automatic fix: convert tenant admin group id to tenant contract id 
+    const idType = await this.client.AccessType({ id });
+    if (idType === this.client.authClient.ACCESS_TYPES.GROUP) {
+      let groupAddress = this.client.utils.HashToAddress(id);
+
+      let tenantContractIdHex = await this.client.CallContractMethod({
+        contractAddress: groupAddress,
+        methodName: "getMeta",
+        methodArgs: ["_ELV_TENANT_ID"], 
+      });
+
+      if (tenantContractIdHex == "0x") {
+        let args = group.split("_");
+        throw (`${args[0]} ${args[1]} group is not associated with any tenant`);
+      }
+      id = ethers.utils.toUtf8String(tenantContractIdHex);
     }
 
     await this.client.userProfileClient.SetTenantContractId({

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -113,7 +113,7 @@ class ElvSpace {
       this.client.SetSigner({ signer: account_signer });
 
       // Assign the created tenant to account
-      //elvAccount.SetAccountTenantContractId(tenant.id);
+      elvAccount.SetAccountTenantContractId(tenant.id);
 
       // Add _ELV_TENANT_ID to groups' metadata so we can identify the tenant these groups belong to
       await this.client.CallContractMethodAndWait({

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -113,7 +113,7 @@ class ElvSpace {
       this.client.SetSigner({ signer: account_signer });
 
       // Assign the created tenant to account
-      elvAccount.SetAccountTenantContractAddress(tenant.address);
+      //elvAccount.SetAccountTenantContractId(tenant.id);
 
       // Add _ELV_TENANT_ID to groups' metadata so we can identify the tenant these groups belong to
       await this.client.CallContractMethodAndWait({

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -175,6 +175,7 @@ class ElvTenant {
    */
   async TenantShow({ tenantId, show_metadata = false }) {
     let tenantInfo = {};
+    
     const tenantAddr = Utils.HashToAddress(tenantId);
     const abi = fs.readFileSync(
       path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -175,8 +175,6 @@ class ElvTenant {
    */
   async TenantShow({ tenantId, show_metadata = false }) {
     let tenantInfo = {};
-    console.log(show_metadata);
-
     const tenantAddr = Utils.HashToAddress(tenantId);
     const abi = fs.readFileSync(
       path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
@@ -234,7 +232,7 @@ class ElvTenant {
     }
 
     if (show_metadata) {
-      let services = {};
+      let services = [];
       let tenantObjectId = ElvUtils.AddressToId({prefix: "iq__", address: tenantAddr});
       let tenantLibraryId = await this.client.ContentObjectLibraryId({objectId: tenantObjectId});
 
@@ -242,15 +240,16 @@ class ElvTenant {
         let liveId = await this.client.ContentObjectMetadata({
           libraryId: tenantLibraryId,
           objectId: tenantObjectId,
+          noAuth: true,
           select:"public/eluvio_live_id",
         });
+        services.push(liveId["public"]);
 
-        services["eluvio_live_id"] = liveId;
-        console.log(liveId);
       } catch (e) {
         console.log(e);
         errors.push("Encountered an error when getting metadata for the eluvio_live_id service");
       }
+      tenantInfo["services"] = services;
     }
 
     if (errors.length != 0) {

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -173,8 +173,9 @@ class ElvTenant {
    * Return tenant admins group and content admins group corresponding to this tenant.
    * @param {string} tenantId - The ID of the tenant (iten***)
    */
-  async TenantShow({ tenantId }) {
+  async TenantShow({ tenantId, show_metadata = false }) {
     let tenantInfo = {};
+    console.log(show_metadata);
 
     const tenantAddr = Utils.HashToAddress(tenantId);
     const abi = fs.readFileSync(
@@ -229,6 +230,26 @@ class ElvTenant {
             errors.push(`${args[0]} ${args[1]} group doesn't belong to this tenant`);
           }
         }
+      }
+    }
+
+    if (show_metadata) {
+      let services = {};
+      let tenantObjectId = ElvUtils.AddressToId({prefix: "iq__", address: tenantAddr});
+      let tenantLibraryId = await this.client.ContentObjectLibraryId({objectId: tenantObjectId});
+
+      try {
+        let liveId = await this.client.ContentObjectMetadata({
+          libraryId: tenantLibraryId,
+          objectId: tenantObjectId,
+          select:"public/eluvio_live_id",
+        });
+
+        services["eluvio_live_id"] = liveId;
+        console.log(liveId);
+      } catch (e) {
+        console.log(e);
+        errors.push("Encountered an error when getting metadata for the eluvio_live_id service");
       }
     }
 

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -175,7 +175,7 @@ class ElvTenant {
    */
   async TenantShow({ tenantId, show_metadata = false }) {
     let tenantInfo = {};
-    
+
     const tenantAddr = Utils.HashToAddress(tenantId);
     const abi = fs.readFileSync(
       path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -88,7 +88,7 @@ const SetTenantEluvioLiveId = async (client, tenantId, eluvioLiveId) => {
   });
 
   return res;
-}
+};
 
 const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
   let tenantAdminId = await client.userProfileClient.TenantId();
@@ -286,7 +286,6 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
 
   /* Add ids of services to tenant fabric metadata */
   await SetTenantEluvioLiveId(client, tenantId, liveTypeIds[TYPE_LIVE_TENANT]);
-
 
   /* Create libraries - Properties, Title Masters, Title Mezzanines and add each to the groups */
 

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -62,6 +62,34 @@ const SetObjectPermissions = async (client, objectId, tenantAdmins, contentAdmin
   await Promise.all(promises);
 };
 
+const SetTenantEluvioLiveId = async (client, tenantId, eluvioLiveId) => {
+  const tenantAddr = Utils.HashToAddress(tenantId);
+  const libraryId = ElvUtils.AddressToId({prefix: "ilib", address: tenantAddr});
+  const objectId = ElvUtils.AddressToId({prefix: "iq__", address: tenantAddr});
+
+  var e = await client.EditContentObject({
+    libraryId,
+    objectId,  
+  });
+
+  await client.ReplaceMetadata({
+    libraryId,
+    objectId,
+    writeToken: e.write_token,
+    metadataSubtree: "public/eluvio_live_id",
+    metadata: eluvioLiveId,
+  });
+
+  const res = await client.FinalizeContentObject({
+    libraryId,
+    objectId,
+    writeToken: e.write_token,
+    commitMessage: "Set Eluvio Live object ID " + eluvioLiveId,
+  });
+
+  return res;
+}
+
 const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
   let tenantAdminId = await client.userProfileClient.TenantId();
   let tenantAdminSigner = client.signer;
@@ -83,7 +111,7 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     formatArguments: true,
   });
 
-  let tenantAdminGroupAddress = await client.CallContractMethodAndWait({
+  let tenantAdminGroupAddress = await client.CallContractMethod({
     contractAddress: tenantAddr,
     abi: JSON.parse(abi),
     methodName: "groupsMapping",
@@ -91,7 +119,7 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     formatArguments: true,
   });
   
-  let contentAdminGroupAddress = await client.CallContractMethodAndWait({
+  let contentAdminGroupAddress = await client.CallContractMethod({
     contractAddress: tenantAddr,
     abi: JSON.parse(abi),
     methodName: "groupsMapping",
@@ -255,6 +283,9 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     }
     liveTypeIds[liveTypes[i].name] = typeId;
   }
+
+  /* Add ids of services to tenant fabric metadata */
+  await SetTenantEluvioLiveId(client, tenantId, liveTypeIds[TYPE_LIVE_TENANT]);
 
 
   /* Create libraries - Properties, Title Masters, Title Mezzanines and add each to the groups */

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -1,7 +1,6 @@
 const { ElvSpace } = require("../src/ElvSpace.js");
 const { ElvTenant } = require("../src/ElvTenant.js");
 const { ElvAccount } = require("../src/ElvAccount.js");
-const { ElvFabric } = require("../src/ElvFabric.js");
 const { ElvContracts } = require("../src/ElvContracts.js");
 const { Config } = require("../src/Config.js");
 
@@ -250,7 +249,8 @@ const CmdTenantShow = async({ argv }) => {
     await t.Init({ privateKey: process.env.PRIVATE_KEY });
 
     let res = await t.TenantShow({
-      tenantId: argv.tenant
+      tenantId: argv.tenant,
+      show_metadata: argv.show_metadata
     });
 
     console.log(yaml.dump(res));
@@ -1035,6 +1035,10 @@ yargs(hideBin(process.argv))
         .positional("tenant", {
           describe: "Tenant ID",
           type: "string",
+        })
+        .option("show_metadata", {
+          describe: "Show the content fabric metadata associated to this tenant",
+          type: "boolean",
         });
     },
     (argv) => {


### PR DESCRIPTION
In provision: when Eluvio Live Object is created, add its Id to the tenant content fabric.
In ElvTenant: Show the details about services (now only Eluvio Live) in TenantShow when --tenant_showmeta is specified